### PR TITLE
Add TWILIO_BYPASS_CODE for local dev to avoid real SMS costs

### DIFF
--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -11,6 +11,7 @@ export type Env = {
   twilioAccountSid: string,
   twilioAuthToken: string,
   twilioVerifyServiceSid: string,
+  twilioBypassCode: string | undefined,
 }
 
 export function env(): Env {
@@ -29,5 +30,6 @@ export function env(): Env {
     twilioAccountSid: process.env.TWILIO_ACCOUNT_SID ?? '',
     twilioAuthToken: process.env.TWILIO_AUTH_TOKEN ?? '',
     twilioVerifyServiceSid: process.env.TWILIO_VERIFY_SERVICE_SID ?? '',
+    twilioBypassCode: process.env.TWILIO_BYPASS_CODE,
   }
 }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -24,8 +24,14 @@ auth.post('/send-code', async (context) => {
 
   const phoneNumber = normalizePhoneNumber(body.phoneNumber)
 
+  const { twilioBypassCode, twilioVerifyServiceSid } = env()
+
+  if (twilioBypassCode) {
+    console.warn(`[DEV] Twilio bypassed for ${phoneNumber} — use code: ${twilioBypassCode}`)
+    return context.json({ success: true })
+  }
+
   const client = getTwilioClient()
-  const { twilioVerifyServiceSid } = env()
 
   try {
     await client.verify.v2
@@ -51,23 +57,30 @@ auth.post('/verify-code', async (context) => {
 
   const phoneNumber = normalizePhoneNumber(body.phoneNumber)
 
-  const client = getTwilioClient()
-  const { twilioVerifyServiceSid } = env()
+  const { twilioBypassCode, twilioVerifyServiceSid } = env()
 
-  try {
-    const verification = await client.verify.v2
-      .services(twilioVerifyServiceSid)
-      .verificationChecks.create({
-        to: phoneNumber,
-        code: body.code,
-      })
-
-    if (verification.status !== 'approved') {
+  if (twilioBypassCode) {
+    if (body.code !== twilioBypassCode) {
       throw new HttpError(401, 'Invalid verification code')
     }
-  } catch (error) {
-    console.error('Twilio verify-code error:', error)
-    throw new HttpError(400, 'Verification failed')
+  } else {
+    const client = getTwilioClient()
+
+    try {
+      const verification = await client.verify.v2
+        .services(twilioVerifyServiceSid)
+        .verificationChecks.create({
+          to: phoneNumber,
+          code: body.code,
+        })
+
+      if (verification.status !== 'approved') {
+        throw new HttpError(401, 'Invalid verification code')
+      }
+    } catch (error) {
+      console.error('Twilio verify-code error:', error)
+      throw new HttpError(400, 'Verification failed')
+    }
   }
 
   const db = getDb()


### PR DESCRIPTION
When TWILIO_BYPASS_CODE is set, /send-code skips the Twilio API call
and logs the code to the console; /verify-code accepts the bypass code
directly. Production behavior is unchanged when the env var is absent.

https://claude.ai/code/session_01CRQNpyrjekU5QUhTa4u55u