### PR TITLE
switch player image picker to expo-image-picker

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -26,6 +26,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         faceIDPermission: 'Allow Birdogey to use Face ID for sign-in.',
       },
     ],
+    [
+      'expo-image-picker',
+      {
+        photosPermission: 'Allow Birdogey to access your photos so you can set a player image.',
+      },
+    ],
   ],
   extra: {
     ...config.extra,

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "expo-dev-client": "~55.0.27",
     "expo-document-picker": "~55.0.13",
     "expo-font": "~55.0.4",
+    "expo-image-picker": "~55.0.18",
     "expo-linking": "~55.0.9",
     "expo-local-authentication": "~55.0.13",
     "expo-router": "~55.0.8",

--- a/mobile/src/components/UserImageUpload.tsx
+++ b/mobile/src/components/UserImageUpload.tsx
@@ -1,6 +1,6 @@
 import { Alert, Pressable, StyleSheet, View } from 'react-native'
 import { useState } from 'react'
-import * as DocumentPicker from 'expo-document-picker'
+import * as ImagePicker from 'expo-image-picker'
 import { UserImage } from '@/components/UserImage'
 import { useApiClient } from '@/contexts/ApiClientContext'
 import { config } from '@/config/env'
@@ -24,16 +24,24 @@ export function UserImageUpload({ imageUrl, onImageUrlChange, disabled }: UserIm
   async function pickImage(): Promise<void> {
     if (loading || disabled) return
 
-    const result = await DocumentPicker.getDocumentAsync({
-      type: 'image/*',
-      copyToCacheDirectory: true,
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync()
+    if (!permission.granted) {
+      Alert.alert('Permission needed', 'Allow photo library access to choose an image.')
+      return
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
     })
 
     if (result.canceled) return
 
     const [asset] = result.assets
 
-    if (asset.size !== undefined && asset.size > MAX_FILE_SIZE) {
+    if (asset.fileSize !== undefined && asset.fileSize > MAX_FILE_SIZE) {
       Alert.alert(`Image must be smaller than ${MAX_FILE_SIZE / 1024 / 1024}MB`)
       return
     }
@@ -41,20 +49,22 @@ export function UserImageUpload({ imageUrl, onImageUrlChange, disabled }: UserIm
     void upload(asset)
   }
 
-  async function upload(asset: DocumentPicker.DocumentPickerAsset): Promise<void> {
+  async function upload(asset: ImagePicker.ImagePickerAsset): Promise<void> {
     setLoading(true)
     setProgress(0)
 
     try {
       const auth = await api.imagekit.authenticate()
 
+      const fileName = asset.fileName ?? asset.uri.split('/').pop() ?? 'photo.jpg'
+
       const formData = new FormData()
       formData.append('file', {
         uri: asset.uri,
-        name: asset.name,
+        name: fileName,
         type: asset.mimeType ?? 'image/jpeg',
       } as unknown as Blob)
-      formData.append('fileName', asset.name)
+      formData.append('fileName', fileName)
       formData.append('publicKey', config.imageKitPublicKey)
       formData.append('token', auth.token)
       formData.append('expire', String(auth.expire))

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "expo-dev-client": "~55.0.27",
         "expo-document-picker": "~55.0.13",
         "expo-font": "~55.0.4",
+        "expo-image-picker": "~55.0.18",
         "expo-linking": "~55.0.9",
         "expo-local-authentication": "~55.0.13",
         "expo-router": "~55.0.8",
@@ -8928,6 +8929,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.19.tgz",
+      "integrity": "sha512-PqOOfRz7+hbB9IFN0LfNxpJJwuPlUG0Abr0qM3Wc61OJ7FFyuKJ50QJ/fFItzSuoXifET1YIFBiXx5nA8Gkinw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {


### PR DESCRIPTION
expo-document-picker only opens the Files app on iOS, which hides the photo library. Swap UserImageUpload to expo-image-picker so it opens the photos picker instead. Adds the expo-image-picker config plugin with NSPhotoLibraryUsageDescription and requests media library permission before launching the picker. allowsEditing + 1:1 aspect gives a square crop suited to the circular avatar.

https://claude.ai/code/session_01WNT25NUDMUjK54K3vAv5mz