### PR TITLE
fix(mobile): materialize .env.production from EAS file env

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src app app.config.ts",
     "lint:fix": "eslint src app app.config.ts --fix",
     "typecheck": "tsc --noEmit",
-    "eas-build-post-install": "cd .. && npm run build -w shared",
+    "eas-build-post-install": "if [ -n \"$MOBILE_ENV_PRODUCTION_FILE\" ]; then cp \"$MOBILE_ENV_PRODUCTION_FILE\" .env.production; fi && cd .. && npm run build -w shared",
     "eas-build": "eas build -p ios --profile production",
     "eas-deploy": "eas submit -p ios --latest"
   },


### PR DESCRIPTION
## Summary
- `.env.production` is gitignored, so the EAS clone has no env file for varlock to load. Required vars (`API_BASE_URL`, `IMAGEKIT_URL`, `IMAGEKIT_PUBLIC_KEY`) end up undefined in the bundle, which is the likely cause of the immediate launch crash on the production iOS build deployed yesterday.
- This change copies the uploaded EAS file env into `mobile/.env.production` during `eas-build-post-install`, so metro/varlock can bundle it at build time.

## Required before this fix takes effect
One-time CLI step (from `mobile/`):

```sh
eas env:create \
  --environment production \
  --scope project \
  --name MOBILE_ENV_PRODUCTION_FILE \
  --type file \
  --value ./.env.production
```

Then `npm run eas-build && npm run eas-deploy`.

## Test plan
- [ ] Run the `eas env:create` command above
- [ ] Trigger a production EAS build and confirm metro bundle phase finishes without varlock warnings about missing required vars
- [ ] Install the resulting build via TestFlight and confirm the app launches past the splash screen
- [ ] Confirm a test event reaches Sentry (proves `ENV.SENTRY_DSN` resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)