### PR TITLE
fix(mobile): chdir to mobile/ in metro config so varlock finds .env.schema

### DIFF
--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,9 +1,18 @@
 const { getDefaultConfig } = require('expo/metro-config');
-const { withVarlockMetroConfig } = require('@varlock/expo-integration/metro-config');
 const path = require('path');
 
 const projectRoot = __dirname;
 const monorepoRoot = path.resolve(projectRoot, '..');
+
+// Varlock's babel plugin and metro-config wrapper both spawn `varlock load`
+// without setting cwd, so the subprocess walks up from the parent's cwd
+// looking for .env.schema. On EAS, xcodebuild's bundle phase has cwd at the
+// monorepo root, where there's no schema, so varlock silently returns an
+// empty config — ENV.X references stay un-inlined and throw at runtime.
+// Force cwd to mobile/ before the wrapper loads.
+process.chdir(projectRoot);
+
+const { withVarlockMetroConfig } = require('@varlock/expo-integration/metro-config');
 
 const config = getDefaultConfig(projectRoot);
 


### PR DESCRIPTION
## Summary

Reproduces locally: \`varlock load --format json-full\` from \`mobile/\` returns the full populated config; from the monorepo root it returns \`config: {}\` — silently, no error. EAS's xcodebuild bundle phase inherits a cwd that isn't \`mobile/\`, so varlock's babel plugin and metro-config wrapper (which both spawn \`varlock load\` without an explicit cwd) end up with empty configs. \`ENV.*\` references survive inlining and the runtime proxy throws \`Error: varlock ENV not initialized\` on app launch.

This was the actual root cause of the iOS launch crash in builds 12–15.

## Change

One line in [mobile/metro.config.js](mobile/metro.config.js): \`process.chdir(projectRoot)\` before \`withVarlockMetroConfig\` is required. Metro workers inherit cwd, so the babel plugin's varlock subprocess also walks from the right directory.

## Test plan
- [ ] Merge, rebuild, resubmit (\`npm run eas-build && npm run eas-deploy\`)
- [ ] Confirm new TestFlight build launches past the splash screen on a device
- [ ] Confirm a test event reaches Sentry (proves \`ENV.SENTRY_DSN\` resolved at build time)
- [ ] If it still crashes the same way: add \`DEBUG=varlock:*\` to \`eas.json\` env and rebuild for verbose varlock logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)