### PR TITLE
chore(mobile): make eas-build and eas-deploy non-interactive

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -11,8 +11,8 @@
     "lint:fix": "eslint src app app.config.ts --fix",
     "typecheck": "tsc --noEmit",
     "eas-build-post-install": "echo '[post-install] writing .env.production from EAS env' && : ${API_BASE_URL:?missing in EAS env} && : ${IMAGEKIT_URL:?missing in EAS env} && : ${IMAGEKIT_PUBLIC_KEY:?missing in EAS env} && printf 'NODE_ENV=production\\nAPI_BASE_URL=%s\\nIMAGEKIT_URL=%s\\nIMAGEKIT_PUBLIC_KEY=%s\\n' \"$API_BASE_URL\" \"$IMAGEKIT_URL\" \"$IMAGEKIT_PUBLIC_KEY\" > .env.production && echo '[post-install] .env.production written:' && cat .env.production && cd .. && npm run build -w shared",
-    "eas-build": "eas build -p ios --profile production",
-    "eas-deploy": "eas submit -p ios --latest"
+    "eas-build": "eas build -p ios --profile production --non-interactive",
+    "eas-deploy": "eas submit -p ios --latest --non-interactive"
   },
   "dependencies": {
     "@birdogey/shared": "*",


### PR DESCRIPTION
## Summary

Skip the interactive prompts that \`eas build\` and \`eas submit\` ask on every run:
- \`Do you want to log in to your Apple account? … yes\`
- \`Apple ID: … ev@nsuther.land\`

Credentials are already stored in EAS (remote iOS credentials + App Store Connect API key), so \`--non-interactive\` mode uses those without re-asking. \`npm run eas-build && npm run eas-deploy\` now runs end-to-end without blocking on prompts.

## Test plan
- [ ] Run \`npm run eas-build\` from \`mobile/\` and confirm it kicks off without any prompts
- [ ] Run \`npm run eas-deploy\` and confirm it submits without prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)