### PR TITLE
fix(mobile): chdir in babel.config.js too + DEBUG=varlock:* for diagnostics

### DIFF
--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,3 +1,14 @@
+// Force cwd to this dir before requiring the varlock babel plugin. Its
+// `loadVarlockConfig()` runs at module load and spawns `varlock load` as
+// a subprocess that inherits cwd from this worker. On EAS the worker's
+// inherited cwd isn't mobile/, so varlock can't find .env.schema and
+// returns an empty config (silently — no error, just ENV.X references
+// survive inlining and the runtime proxy throws).
+if (process.cwd() !== __dirname) {
+  process.stderr.write(`[babel.config.js] chdir from ${process.cwd()} to ${__dirname}\n`);
+  process.chdir(__dirname);
+}
+
 module.exports = function (api) {
   api.cache(true);
   return {

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -24,7 +24,8 @@
       },
       "env": {
         "SENTRY_DISABLE_AUTO_UPLOAD": "true",
-        "NODE_ENV": "production"
+        "NODE_ENV": "production",
+        "DEBUG": "varlock:*"
       }
     }
   },

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -10,7 +10,10 @@ const monorepoRoot = path.resolve(projectRoot, '..');
 // monorepo root, where there's no schema, so varlock silently returns an
 // empty config — ENV.X references stay un-inlined and throw at runtime.
 // Force cwd to mobile/ before the wrapper loads.
-process.chdir(projectRoot);
+if (process.cwd() !== projectRoot) {
+  process.stderr.write(`[metro.config.js] chdir from ${process.cwd()} to ${projectRoot}\n`);
+  process.chdir(projectRoot);
+}
 
 const { withVarlockMetroConfig } = require('@varlock/expo-integration/metro-config');
 


### PR DESCRIPTION
## Summary

Build 16 (with the metro.config.js chdir from [#16](https://github.com/stackoverfloweth/birdogey/pull/16)) still crashed at runtime with \`Error: varlock ENV not initialized\`. That tells us the chdir in metro main didn't propagate to wherever varlock's babel plugin actually runs.

Looking at \`@varlock/expo-integration/babel-plugin\` more carefully: it calls \`loadVarlockConfig()\` at **module-load time, once per metro worker process**. If metro spawns workers with an explicit cwd (or before metro.config.js evaluates), the worker's cwd is not \`mobile/\` when the plugin loads, varlock's subprocess inherits that wrong cwd, finds no \`.env.schema\`, returns empty config — and \`ENV.X\` references survive inlining.

## Changes

- **babel.config.js**: chdir to \`__dirname\` at the top, before requiring the varlock babel plugin. This runs in each worker, so the chdir is local to where the actual varlock subprocess gets spawned.
- **metro.config.js**: added stderr log around the existing chdir so the build log tells us what cwd it was at.
- **eas.json**: set \`DEBUG=varlock:*\` in the production profile env so varlock's internal debug logging shows up in EAS build logs.

After the next build, the EAS log will tell us definitively:
1. What cwd metro main had before chdir
2. What cwd each metro worker had before chdir
3. Exactly what varlock saw when it ran (via \`debug\` output)

Either the chdir lines fix the crash, or the debug output reveals what's actually going wrong. Either way, no more guessing.

## Test plan
- [ ] Merge, rebuild, resubmit
- [ ] In the EAS build log, confirm \`[babel.config.js] chdir from ... to .../mobile\` lines appear
- [ ] Look for \`varlock:expo-integration\` debug lines around the babel plugin's load
- [ ] Install TestFlight build on device, confirm it launches past the splash screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)