### PR TITLE
fix(mobile): pin ascAppId so non-interactive eas submit works

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -30,6 +30,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6766069012"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

The \`--non-interactive\` flag added in [#17](https://github.com/stackoverfloweth/birdogey/pull/17) made \`eas submit\` fail with \`Set ascAppId in the submit profile (eas.json) or re-run this command in interactive mode.\` because EAS couldn't prompt for the App Store Connect app ID.

Pin it explicitly under \`submit.production.ios.ascAppId\`. The ID (\`6766069012\`) came from the previous interactive submit log.

## Test plan
- [ ] Run \`npm run eas-deploy\` and confirm submission completes without prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)