### PR TITLE
fix(mobile): switch to appVersionSource=remote so EAS tracks build numbers

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "development": {


### PR DESCRIPTION
## Summary

Submission failed with \`Build number 17 for app version 1.0.0 has already been used\` because the committed \`buildNumber\` in [app.json](mobile/app.json) is still \"12\" — wildly out of sync with reality after ~17 builds. With \`appVersionSource: \"local\"\` + \`autoIncrement: \"buildNumber\"\`, EAS bumps the value on the remote build machine but never commits it back to git, so the source-controlled value drifts behind every build.

Switching to \`appVersionSource: \"remote\"\` makes EAS track the build number server-side, independent of \`app.json\`. No more drift, no more \"already used\" surprises.

## One-time CLI step required

Before the next build, run:

\`\`\`sh
eas build:version:set --platform ios
\`\`\`

Enter \`18\` (or any value higher than 17 — App Store Connect's highest build for v1.0.0). EAS uses that as the starting server-side value, then auto-increments from there on every subsequent build.

## Test plan
- [ ] Run \`eas build:version:set --platform ios\` and set to 18
- [ ] \`npm run eas-build && npm run eas-deploy\` — confirm build is numbered 19 (or higher) and submit succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)