### PR TITLE
fix(mobile): inject cwd into varlock subprocess via execSync monkey-patch

### DIFF
--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,13 +1,43 @@
-// Force cwd to this dir before requiring the varlock babel plugin. Its
-// `loadVarlockConfig()` runs at module load and spawns `varlock load` as
-// a subprocess that inherits cwd from this worker. On EAS the worker's
-// inherited cwd isn't mobile/, so varlock can't find .env.schema and
-// returns an empty config (silently — no error, just ENV.X references
-// survive inlining and the runtime proxy throws).
-if (process.cwd() !== __dirname) {
-  process.stderr.write(`[babel.config.js] chdir from ${process.cwd()} to ${__dirname}\n`);
-  process.chdir(__dirname);
+// Force every `varlock` subprocess to run with cwd=this directory so it
+// finds .env.schema regardless of what cwd the metro worker happens to
+// have. The babel plugin in @varlock/expo-integration calls execSync
+// without passing cwd, so its subprocess inherits whatever metro gave
+// the worker - on EAS that's not mobile/. Result: varlock walks up from
+// the wrong place, finds no schema, returns empty config, ENV.X
+// references survive inlining, runtime proxy throws "ENV not
+// initialized". Monkey-patching execSync/execFileSync to inject cwd is
+// the only way to force the subprocess to look in the right place
+// without modifying node_modules.
+const child_process = require('child_process');
+const projectRoot = __dirname;
+
+process.stderr.write(`[babel.config.js] cwd=${process.cwd()} projectRoot=${projectRoot}\n`);
+
+const originalExecSync = child_process.execSync;
+const originalExecFileSync = child_process.execFileSync;
+
+function looksLikeVarlock(target) {
+  if (typeof target !== 'string') return false;
+  if (target === 'varlock') return true;
+  if (target.endsWith('/varlock') || target.endsWith('\\varlock')) return true;
+  return /^varlock(\s|$)/.test(target);
 }
+
+child_process.execSync = function patchedExecSync(command, options) {
+  if (looksLikeVarlock(command) && !(options && options.cwd)) {
+    process.stderr.write(`[babel.config.js] injecting cwd=${projectRoot} into varlock execSync\n`);
+    options = { ...options, cwd: projectRoot };
+  }
+  return originalExecSync.call(this, command, options);
+};
+
+child_process.execFileSync = function patchedExecFileSync(file, args, options) {
+  if (looksLikeVarlock(file) && !(options && options.cwd)) {
+    process.stderr.write(`[babel.config.js] injecting cwd=${projectRoot} into varlock execFileSync\n`);
+    options = { ...options, cwd: projectRoot };
+  }
+  return originalExecFileSync.call(this, file, args, options);
+};
 
 module.exports = function (api) {
   api.cache(true);


### PR DESCRIPTION
## Summary

The chdir attempts in [#16](https://github.com/stackoverfloweth/birdogey/pull/16) and [#18](https://github.com/stackoverfloweth/birdogey/pull/18) didn't fix the launch crash. Build 18's debug output showed \`varlock:expo-integration static replacements keys []\` for every worker — varlock CLI ran successfully but with zero keys in its config. Same silent failure I reproduced locally by running \`varlock load\` from a directory above the schema: empty config, no error.

That confirms varlock's subprocess on EAS spawns with a cwd that isn't \`mobile/\`. My chdir in \`babel.config.js\` top-level apparently doesn't reach the worker that actually runs the babel plugin (no breadcrumb appeared in the log), and chdir in \`metro.config.js\` doesn't propagate to babel workers either.

## Change

Stop relying on cwd inheritance. Monkey-patch \`child_process.execSync\` / \`execFileSync\` in \`babel.config.js\` to inject \`cwd: __dirname\` whenever the command is \`varlock\`. The @varlock/expo-integration babel plugin calls execSync without passing cwd, so our patched version supplies it from the only place we can know it: \`__dirname\` of babel.config.js. No more cwd-inheritance question.

## Test plan
- [ ] Merge, rebuild, resubmit
- [ ] In the new EAS build log, confirm \`[babel.config.js] injecting cwd=.../mobile into varlock\` appears
- [ ] Confirm \`varlock:expo-integration static replacements keys\` shows a non-empty array (e.g. \`['NODE_ENV', 'API_BASE_URL', 'IMAGEKIT_URL', 'IMAGEKIT_PUBLIC_KEY']\`)
- [ ] Install TestFlight build on device, confirm it launches past the splash screen

## Fallback if this doesn't fire

If \`[babel.config.js]\` lines never appear in the log, it means metro caches \`babel.config.js\` in a way our top-level patches don't reach. Next step would be patch-package on \`@varlock/expo-integration/babel-plugin.js\` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)