### PR TITLE
fix(mobile): write ios/package.json shim to hint varlock at the schema location

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint src app app.config.ts",
     "lint:fix": "eslint src app app.config.ts --fix",
     "typecheck": "tsc --noEmit",
-    "eas-build-post-install": "echo '[post-install] writing .env.production from EAS env' && : ${API_BASE_URL:?missing in EAS env} && : ${IMAGEKIT_URL:?missing in EAS env} && : ${IMAGEKIT_PUBLIC_KEY:?missing in EAS env} && printf 'NODE_ENV=production\\nAPI_BASE_URL=%s\\nIMAGEKIT_URL=%s\\nIMAGEKIT_PUBLIC_KEY=%s\\n' \"$API_BASE_URL\" \"$IMAGEKIT_URL\" \"$IMAGEKIT_PUBLIC_KEY\" > .env.production && echo '[post-install] .env.production written:' && cat .env.production && cd .. && npm run build -w shared",
+    "eas-build-post-install": "echo '[post-install] writing .env.production from EAS env' && : ${API_BASE_URL:?missing in EAS env} && : ${IMAGEKIT_URL:?missing in EAS env} && : ${IMAGEKIT_PUBLIC_KEY:?missing in EAS env} && printf 'NODE_ENV=production\\nAPI_BASE_URL=%s\\nIMAGEKIT_URL=%s\\nIMAGEKIT_PUBLIC_KEY=%s\\n' \"$API_BASE_URL\" \"$IMAGEKIT_URL\" \"$IMAGEKIT_PUBLIC_KEY\" > .env.production && echo '[post-install] .env.production written:' && cat .env.production && mkdir -p ios && printf '{\"name\":\"birdogey-ios-cwd-shim\",\"private\":true,\"varlock\":{\"loadPath\":\"..\"}}\\n' > ios/package.json && echo '[post-install] wrote ios/package.json so varlock finds schema when bundle phase runs from ios/:' && cat ios/package.json && cd .. && npm run build -w shared",
     "eas-build": "eas build -p ios --profile production --non-interactive",
     "eas-deploy": "eas submit -p ios --latest --non-interactive"
   },


### PR DESCRIPTION
## Summary

Build logs continue to show \`varlock:expo-integration static replacements keys []\` for every worker even after [#22](https://github.com/stackoverfloweth/birdogey/pull/22) added \`varlock.loadPath\` to root \`package.json\`. That means varlock's subprocess during the Bundle JavaScript phase is running from neither the monorepo root nor \`mobile/\`. The most likely cwd is \`mobile/ios/\` — that's where xcodebuild's bundle script normally starts.

\`mobile/ios/\` is gitignored and regenerated by Expo prebuild on every EAS run, so we can't check in a static file there. Instead, this PR has the \`eas-build-post-install\` hook (which runs *after* prebuild) write a minimal \`ios/package.json\` shim:

\`\`\`json
{
  \"name\": \"birdogey-ios-cwd-shim\",
  \"private\": true,
  \"varlock\": { \"loadPath\": \"..\" }
}
\`\`\`

When varlock's subprocess later runs with \`cwd=mobile/ios/\` during the bundle phase, it reads this \`package.json\`, follows \`loadPath: \"..\"\` back up to \`mobile/\`, and finds the schema.

## What we'll learn from the next build

- If the new build's \`static replacements keys [...]\` is non-empty → confirms cwd was \`mobile/ios/\` and we're unblocked.
- If still empty → cwd is something else entirely (we'll have ruled out all three obvious locations: root, mobile/, mobile/ios/), and we should move to patch-package or commit \`.env.production\`.

Either result is informative.

## Test plan
- [ ] Merge, rebuild, resubmit
- [ ] Build log shows the \`[post-install] wrote ios/package.json...\` line and the JSON contents
- [ ] Bundle JavaScript phase shows \`varlock:expo-integration static replacements keys\` with populated keys (not \`[]\`)
- [ ] TestFlight build launches past splash screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)