### PR TITLE
Add frozen tag support for players who forget their tag

### DIFF
--- a/mobile/src/components/EventPlayerForm.tsx
+++ b/mobile/src/components/EventPlayerForm.tsx
@@ -2,7 +2,7 @@ import { formStyles } from '@/theme/forms'
 import { colors } from '@/theme/colors'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Controller, useForm } from 'react-hook-form'
-import { View, Text, Pressable, ActivityIndicator } from 'react-native'
+import { View, Text, Pressable, ActivityIndicator, Switch } from 'react-native'
 import { eventPlayerSchema, EventPlayerSchema, EventPlayerSchemaInput } from '@birdogey/shared'
 import { NumericInput } from './NumericInput'
 
@@ -53,6 +53,24 @@ export function EventPlayerForm({ submitText, submitIcon, initialValues, onSubmi
           />
           {errors.outgoingTagId && <Text style={formStyles.errorText}>{errors.outgoingTagId.message}</Text>}
         </View>
+      </View>
+
+      <View style={formStyles.formGroup}>
+        <Text style={formStyles.label}>Freeze Tag</Text>
+        <Text style={{ color: colors.on_surface_variant, fontSize: 12 }}>Forgot their tag — they keep their incoming tag when the event completes</Text>
+        <Controller
+          control={control}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <Switch
+              trackColor={{ true: colors.primary }}
+              value={value ?? false}
+              onValueChange={onChange}
+              onBlur={onBlur}
+            />
+          )}
+          name="frozen"
+        />
+        {errors.frozen && <Text style={formStyles.errorText}>{errors.frozen.message}</Text>}
       </View>
 
       <View style={formStyles.actions}>

--- a/mobile/src/components/EventPlayersActiveList.tsx
+++ b/mobile/src/components/EventPlayersActiveList.tsx
@@ -101,6 +101,10 @@ export function EventPlayersActiveList({ event, eventPlayers, onPlayersChanged, 
     return playersInEvent.filter((player) => player.score === undefined)
   }, [playersInEvent])
 
+  const frozenPlayers = useMemo(() => {
+    return playersInEvent.filter((player) => player.frozen)
+  }, [playersInEvent])
+
   function confirmCompleteEvent(): void {
     if (playersWithoutScore.length > 0) {
       Alert.alert(`There are ${playersWithoutScore.length} players without a score.`, 'Please add scores for all players before completing the event.')
@@ -197,6 +201,18 @@ export function EventPlayersActiveList({ event, eventPlayers, onPlayersChanged, 
                   {playersWithoutScore.length}
                   {' '}
                   missing score
+                </Text>
+              </View>
+            )}
+            {frozenPlayers.length > 0 && (
+              <View style={{ flexDirection: 'row', gap: 4 }}>
+                <SymbolView name="snowflake" size={16} tintColor={colors.primary} />
+                <Text style={{ color: colors.primary, fontWeight: 'bold' }}>
+                  {frozenPlayers.length}
+                  {' '}
+                  frozen
+                  {' '}
+                  {pluralize(frozenPlayers.length, 'tag')}
                 </Text>
               </View>
             )}

--- a/mobile/src/components/EventPlayersActiveList.tsx
+++ b/mobile/src/components/EventPlayersActiveList.tsx
@@ -101,10 +101,6 @@ export function EventPlayersActiveList({ event, eventPlayers, onPlayersChanged, 
     return playersInEvent.filter((player) => player.score === undefined)
   }, [playersInEvent])
 
-  const frozenPlayers = useMemo(() => {
-    return playersInEvent.filter((player) => player.frozen)
-  }, [playersInEvent])
-
   function confirmCompleteEvent(): void {
     if (playersWithoutScore.length > 0) {
       Alert.alert(`There are ${playersWithoutScore.length} players without a score.`, 'Please add scores for all players before completing the event.')
@@ -201,18 +197,6 @@ export function EventPlayersActiveList({ event, eventPlayers, onPlayersChanged, 
                   {playersWithoutScore.length}
                   {' '}
                   missing score
-                </Text>
-              </View>
-            )}
-            {frozenPlayers.length > 0 && (
-              <View style={{ flexDirection: 'row', gap: 4 }}>
-                <SymbolView name="snowflake" size={16} tintColor={colors.primary} />
-                <Text style={{ color: colors.primary, fontWeight: 'bold' }}>
-                  {frozenPlayers.length}
-                  {' '}
-                  frozen
-                  {' '}
-                  {pluralize(frozenPlayers.length, 'tag')}
                 </Text>
               </View>
             )}

--- a/mobile/src/components/EventPlayersInactiveList.tsx
+++ b/mobile/src/components/EventPlayersInactiveList.tsx
@@ -1,4 +1,4 @@
-import { Event, EventPlayerRequest, pluralize, UserSeason } from '@birdogey/shared'
+import { Event, EventPlayerRequest, UserSeason } from '@birdogey/shared'
 import { useQuery } from '@tanstack/react-query'
 import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View, ViewToken } from 'react-native'
 import { useApiClient } from '@/contexts/ApiClientContext'
@@ -65,10 +65,6 @@ export function EventPlayersInactiveList({ event, eventPlayers, isRefreshing, on
     }))
   }, [getPlayer, eventPlayers, isFetched])
 
-  const frozenPlayers = useMemo(() => {
-    return playersInEvent.filter((player) => player.frozen)
-  }, [playersInEvent])
-
   function renderHeader(): React.ReactElement {
     return (
       <View style={styles.header}>
@@ -93,18 +89,6 @@ export function EventPlayersInactiveList({ event, eventPlayers, isRefreshing, on
             <View>
               <Text style={[cardStyles.cardSecondaryText, { color: colors.on_surface_variant }]}>Total Players</Text>
               <Text style={[cardStyles.cardPrimaryText, { color: colors.on_surface }]}>{eventPlayers.length}</Text>
-              {frozenPlayers.length > 0 && (
-                <View style={{ flexDirection: 'row', gap: 4 }}>
-                  <SymbolView name="snowflake" size={16} tintColor={colors.primary} />
-                  <Text style={{ color: colors.primary, fontWeight: 'bold' }}>
-                    {frozenPlayers.length}
-                    {' '}
-                    frozen
-                    {' '}
-                    {pluralize(frozenPlayers.length, 'tag')}
-                  </Text>
-                </View>
-              )}
             </View>
           </View>
         </View>

--- a/mobile/src/components/EventPlayersInactiveList.tsx
+++ b/mobile/src/components/EventPlayersInactiveList.tsx
@@ -1,4 +1,4 @@
-import { Event, EventPlayerRequest, UserSeason } from '@birdogey/shared'
+import { Event, EventPlayerRequest, pluralize, UserSeason } from '@birdogey/shared'
 import { useQuery } from '@tanstack/react-query'
 import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View, ViewToken } from 'react-native'
 import { useApiClient } from '@/contexts/ApiClientContext'
@@ -65,6 +65,10 @@ export function EventPlayersInactiveList({ event, eventPlayers, isRefreshing, on
     }))
   }, [getPlayer, eventPlayers, isFetched])
 
+  const frozenPlayers = useMemo(() => {
+    return playersInEvent.filter((player) => player.frozen)
+  }, [playersInEvent])
+
   function renderHeader(): React.ReactElement {
     return (
       <View style={styles.header}>
@@ -89,6 +93,18 @@ export function EventPlayersInactiveList({ event, eventPlayers, isRefreshing, on
             <View>
               <Text style={[cardStyles.cardSecondaryText, { color: colors.on_surface_variant }]}>Total Players</Text>
               <Text style={[cardStyles.cardPrimaryText, { color: colors.on_surface }]}>{eventPlayers.length}</Text>
+              {frozenPlayers.length > 0 && (
+                <View style={{ flexDirection: 'row', gap: 4 }}>
+                  <SymbolView name="snowflake" size={16} tintColor={colors.primary} />
+                  <Text style={{ color: colors.primary, fontWeight: 'bold' }}>
+                    {frozenPlayers.length}
+                    {' '}
+                    frozen
+                    {' '}
+                    {pluralize(frozenPlayers.length, 'tag')}
+                  </Text>
+                </View>
+              )}
             </View>
           </View>
         </View>
@@ -105,7 +121,11 @@ export function EventPlayersInactiveList({ event, eventPlayers, isRefreshing, on
 
   function renderSubTitle(player: PlayerInEvent): React.ReactNode {
     return (
-      <Text>{player.outgoingTagId ? `#${player.outgoingTagId}` : 'No tag'}</Text>
+      <View style={{ flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+        <Text>{player.outgoingTagId ? `#${player.outgoingTagId}` : 'No tag'}</Text>
+
+        {player.frozen && <SymbolView name="snowflake" size={14} tintColor={colors.primary} />}
+      </View>
     )
   }
 

--- a/mobile/src/components/PlayerListItemWithSwipeActions.tsx
+++ b/mobile/src/components/PlayerListItemWithSwipeActions.tsx
@@ -59,8 +59,10 @@ export function PlayerListItemWithSwipeActions({ player, visible, onChange, onRe
 
   function renderSubTitle(player: PlayerInEvent): React.ReactNode {
     return (
-      <View style={{ flexDirection: 'row', gap: 12 }}>
+      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
         <Text>{player.incomingTagId ? `#${player.incomingTagId}` : 'No tag'}</Text>
+
+        {player.frozen && <SymbolView name="snowflake" size={14} tintColor={colors.primary} />}
 
         <Text style={aceState ? { color: colors.primary, fontWeight: 'bold' } : { color: colors.outline_variant }}>ACE</Text>
 

--- a/server/src/routes/events.ts
+++ b/server/src/routes/events.ts
@@ -121,6 +121,7 @@ events.post('/', requireAdmin, async (context) => {
     userId: new ObjectId(eventPlayer.userId as string),
     inForCtp: eventPlayer.inForCtp ?? false,
     inForAce: eventPlayer.inForAce ?? false,
+    frozen: eventPlayer.frozen ?? false,
   })) ?? []
 
   const result = await collection.insertOne({
@@ -159,6 +160,7 @@ events.put('/:id', requireAdmin, async (context) => {
     userId: new ObjectId(eventPlayer.userId as string),
     inForCtp: eventPlayer.inForCtp ?? false,
     inForAce: eventPlayer.inForAce ?? false,
+    frozen: eventPlayer.frozen ?? false,
   })) ?? []
 
   const ctpUserIds = body.ctpUserIds?.map((userId: string) => new ObjectId(userId)) ?? []
@@ -194,8 +196,11 @@ events.put('/:id/complete', requireAdmin, async (context) => {
   const collection = db.collection<EventResponse>('events')
 
   const requestPlayers = body.players ?? []
-  const availableTags = requestPlayers.map(({ incomingTagId }: { incomingTagId: number }) => incomingTagId).sort((aTag: number, bTag: number) => aTag - bTag)
-  const sortedByScore = requestPlayers.sort((aPlayer: EventPlayerResponse, bPlayer: EventPlayerResponse) => (aPlayer.score ?? Infinity) - (bPlayer.score ?? Infinity) || aPlayer.incomingTagId - bPlayer.incomingTagId)
+  // frozen players keep their incoming tag, so they are excluded from the
+  // redistribution pool and the score ranking
+  const rankedPlayers = requestPlayers.filter(({ frozen }: { frozen?: boolean }) => !frozen)
+  const availableTags = rankedPlayers.map(({ incomingTagId }: { incomingTagId: number }) => incomingTagId).sort((aTag: number, bTag: number) => aTag - bTag)
+  const sortedByScore = rankedPlayers.sort((aPlayer: EventPlayerResponse, bPlayer: EventPlayerResponse) => (aPlayer.score ?? Infinity) - (bPlayer.score ?? Infinity) || aPlayer.incomingTagId - bPlayer.incomingTagId)
 
   const players = requestPlayers.map((eventPlayer: EventPlayerRequest) => ({
     ...eventPlayer,
@@ -203,7 +208,10 @@ events.put('/:id/complete', requireAdmin, async (context) => {
     userId: new ObjectId(eventPlayer.userId),
     inForCtp: eventPlayer.inForCtp ?? false,
     inForAce: eventPlayer.inForAce ?? false,
-    outgoingTagId: availableTags[sortedByScore.findIndex(({ userId }: { userId: ObjectId }) => userId.toString() === eventPlayer.userId)],
+    frozen: eventPlayer.frozen ?? false,
+    outgoingTagId: eventPlayer.frozen
+      ? eventPlayer.incomingTagId
+      : availableTags[sortedByScore.findIndex(({ userId }: { userId: ObjectId }) => userId.toString() === eventPlayer.userId)],
   }))
 
   const ctpUserIds = body.ctpUserIds?.map((userId: string) => new ObjectId(userId)) ?? []

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -255,6 +255,7 @@ users.put('/:id/checkin', authMiddleware, async (context) => {
         incomingTagId: tagId,
         inForCtp: false,
         inForAce: false,
+        frozen: false,
       },
     },
   })

--- a/shared/models/api/eventPlayerResponse.ts
+++ b/shared/models/api/eventPlayerResponse.ts
@@ -8,4 +8,5 @@ export type EventPlayerResponse = {
   score?: number,
   incomingTagId: number,
   outgoingTagId?: number,
+  frozen?: boolean,
 }

--- a/shared/models/eventPlayer.ts
+++ b/shared/models/eventPlayer.ts
@@ -6,4 +6,5 @@ export type EventPlayer = {
   score?: number,
   incomingTagId: number,
   outgoingTagId?: number,
+  frozen: boolean,
 }

--- a/shared/schemas/eventSchema.ts
+++ b/shared/schemas/eventSchema.ts
@@ -11,6 +11,7 @@ export const eventPlayerSchema = z.object({
   score: z.number().optional(),
   incomingTagId: z.number({ message: 'Incoming tag is required' }),
   outgoingTagId: z.number().optional(),
+  frozen: z.boolean().optional(),
 })
 
 export type EventPlayerSchemaInput = z.input<typeof eventPlayerSchema>

--- a/shared/services/mappers.ts
+++ b/shared/services/mappers.ts
@@ -11,6 +11,7 @@ export function mapEventPlayer(source: EventPlayerJson): EventPlayer {
     score: source.score ?? undefined,
     incomingTagId: source.incomingTagId,
     outgoingTagId: source.outgoingTagId ?? undefined,
+    frozen: source.frozen ?? false,
   }
 }
 

--- a/shared/services/types.ts
+++ b/shared/services/types.ts
@@ -57,6 +57,7 @@ export type EventPlayerJson = {
   score?: number,
   incomingTagId: number,
   outgoingTagId?: number,
+  frozen?: boolean,
 }
 
 export type EventJson = {

--- a/web/src/components/EventPlayerEditModal.vue
+++ b/web/src/components/EventPlayerEditModal.vue
@@ -32,6 +32,7 @@
 
   const incomingTagId = ref(eventPlayer.value.incomingTagId)
   const outgoingTagId = ref(eventPlayer.value.outgoingTagId)
+  const frozen = ref(eventPlayer.value.frozen ?? false)
 
   function close(): void {
     isOpen.value = false
@@ -42,6 +43,7 @@
       ...eventPlayer.value,
       incomingTagId: incomingTagId.value,
       outgoingTagId: outgoingTagId.value,
+      frozen: frozen.value,
     }
     close()
   }
@@ -60,6 +62,12 @@
         <p-label class="event-player-edit-modal__form-outgoing-tag-id" label="Outgoing Tag #">
           <template #default="{ id }">
             <p-number-input :id="id" v-model="outgoingTagId" :min="0" />
+          </template>
+        </p-label>
+
+        <p-label class="event-player-edit-modal__form-frozen" label="Freeze Tag (forgot tag, keeps incoming)">
+          <template #default="{ id }">
+            <p-toggle :id="id" v-model="frozen" />
           </template>
         </p-label>
       </div>
@@ -81,6 +89,11 @@
 .event-player-edit-modal__form {
   display: grid;
   column-gap: var(--space-sm);
+  row-gap: var(--space-sm);
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.event-player-edit-modal__form-frozen {
+  grid-column: 1 / -1;
 }
 </style>

--- a/web/src/components/EventPlayerListItem.vue
+++ b/web/src/components/EventPlayerListItem.vue
@@ -80,6 +80,10 @@
       <div class="event-player-list-item__tag event-player-list-item__tag--outgoing" :class="classes.tag">
         {{ outgoingTagId ?? '--' }}
       </div>
+
+      <div v-if="eventPlayer.frozen" class="event-player-list-item__frozen" title="Tag frozen — keeps incoming tag">
+        ❄
+      </div>
     </div>
 
     <div class="event-player-list-item__image">
@@ -143,8 +147,24 @@
 
 .event-player-list-item__tags-container {
   grid-area: tag;
+  position: relative;
   display: flex;
   justify-content: center;
+}
+
+.event-player-list-item__frozen {
+  position: absolute;
+  top: -6px;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 10px;
+  color: var(--p-color-bg-1);
+  background: var(--p-color-message-info-bg, #00b3fe);
 }
 
 .event-player-list-item__tag {


### PR DESCRIPTION
## What

Adds a per-event-player **frozen** flag for players who show up without their tag. A frozen player leaves the event with the same tag they came in with, regardless of their score.

## Why

Players regularly forget their tag on league night. Until now there was no way to record that — the tag algorithm would redistribute their tag like any other. This also makes it visible (including on past events) who forgot their tag.

## How it works

- **Data**: `frozen?: boolean` on the embedded event player record. No migration needed — missing field reads as `false` everywhere.
- **Tag logic** (`server/src/routes/events.ts` complete endpoint): frozen players are excluded from the available-tag pool and the score ranking, and get `outgoingTagId = incomingTagId`. Everyone else ranks against the remaining tags as before. Uncomplete needed no changes since it restores incoming tags.
- **Web**: "Freeze Tag" toggle in the tag edit modal (`EventPlayerEditModal.vue`); ❄ badge on the tag circles in `EventPlayerListItem.vue`, visible in the read-only completed view too.
- **Mobile**: "Freeze Tag" switch in `EventPlayerForm.tsx`; snowflake indicator next to the tag in the active and completed player lists; "N frozen tags" count on the Total Players header cards.

## Notes for review

- A frozen player's score still counts for CTP/ACE and is still required to complete the event — freezing only affects tag movement.
- Verified with `shared` build/typecheck, `server` tsc, web `vue-tsc`, and `mobile` tsc. The only failures are pre-existing (`server/src/env.d.ts` lint, `UDiscImportModal.vue` button variant type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)