### PR TITLE
Add admin-only private notes on players

### DIFF
--- a/mobile/app/(protected)/players/[id].tsx
+++ b/mobile/app/(protected)/players/[id].tsx
@@ -5,7 +5,7 @@ import { colors } from '@/theme/colors'
 import { cardStyles } from '@/theme/card'
 import { UserRequest } from '@birdogey/shared'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { useLocalSearchParams } from 'expo-router'
+import { router, useLocalSearchParams } from 'expo-router'
 import { SymbolView } from 'expo-symbols'
 import { StyleSheet, View, ActivityIndicator, ScrollView } from 'react-native'
 import { formStyles } from '@/theme/forms'
@@ -23,7 +23,8 @@ export default function PlayerView(): React.ReactNode {
   const { mutate: updatePlayer, isPending: isUpdatingPlayer } = useMutation({
     mutationFn: (player: UserRequest) => api.user.update(id, player),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['players', id] })
+      queryClient.invalidateQueries({ queryKey: ['players'] })
+      router.back()
     },
   })
 

--- a/mobile/app/(protected)/players/index.tsx
+++ b/mobile/app/(protected)/players/index.tsx
@@ -75,6 +75,7 @@ export default function Players(): React.ReactNode {
           <PlayerListItem
             player={item}
             visible={visibleIds.has(item.id)}
+            subTitle={item.privateNotes ? <Text style={styles.privateNotes} numberOfLines={1}>{item.privateNotes}</Text> : undefined}
             onPress={() => router.push(`/players/${item.id}`)}
           />
         )}
@@ -115,6 +116,10 @@ const styles = StyleSheet.create({
   },
   flatList: {
     flex: 1,
+  },
+  privateNotes: {
+    fontSize: 12,
+    color: colors.on_surface_variant,
   },
   list: {
     gap: 12,

--- a/mobile/src/components/PlayerForm.tsx
+++ b/mobile/src/components/PlayerForm.tsx
@@ -85,6 +85,23 @@ export function PlayerForm({ userId, submitText, submitIcon, cancelText, initial
         {errors.udiscId && <Text style={formStyles.errorText}>{errors.udiscId.message}</Text>}
       </View>
 
+      <View style={formStyles.formGroup}>
+        <Text style={formStyles.label}>Private Notes</Text>
+        <Controller
+          control={control}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <TextInput
+              onChangeText={onChange}
+              onBlur={onBlur}
+              value={value}
+              multiline
+            />
+          )}
+          name="privateNotes"
+        />
+        {errors.privateNotes && <Text style={formStyles.errorText}>{errors.privateNotes.message}</Text>}
+      </View>
+
       <View style={formStyles.actions}>
         <Pressable
           disabled={formIsLoading || isLoading}

--- a/mobile/src/components/PlayerListItem.tsx
+++ b/mobile/src/components/PlayerListItem.tsx
@@ -32,7 +32,7 @@ export function PlayerListItem({ player: playerOrPlayerId, visible = true, right
     <Pressable style={styles.container} onPress={onPress}>
       <View style={styles.primary}>
         <UserImage userId={player?.id} imageUrl={visible ? player?.imageUrl : undefined} width={40} height={40} />
-        <View style={{ gap: 2 }}>
+        <View style={{ gap: 2, flexShrink: 1 }}>
           <Text style={styles.primaryText}>{player?.name}</Text>
           {subTitle}
         </View>

--- a/mobile/src/components/PlayersModal.tsx
+++ b/mobile/src/components/PlayersModal.tsx
@@ -1,7 +1,8 @@
-import { StyleSheet, StyleProp, ViewStyle, FlatList, FlatListProps, ListRenderItemInfo } from 'react-native'
+import { StyleSheet, StyleProp, ViewStyle, FlatList, FlatListProps, ListRenderItemInfo, Text } from 'react-native'
 import { User } from '@birdogey/shared'
 import { BottomSheet } from '@/components/BottomSheet'
 import { PlayerListItem } from '@/components/PlayerListItem'
+import { colors } from '@/theme/colors'
 
 type PlayersModalProps<T extends User> = Omit<FlatListProps<T>, 'data' | 'renderItem'> & {
   players: T[],
@@ -15,7 +16,13 @@ type PlayersModalProps<T extends User> = Omit<FlatListProps<T>, 'data' | 'render
 
 export function PlayersModal<T extends User>({ players, visible, beforeList, renderItem, onSelect = () => {}, onDismiss = () => {}, style, ...listProps }: PlayersModalProps<T>): React.ReactNode {
   function defaultRenderItem({ item }: ListRenderItemInfo<T>): React.ReactElement {
-    return <PlayerListItem player={item} onPress={() => onSelect(item)} />
+    return (
+      <PlayerListItem
+        player={item}
+        subTitle={item.privateNotes ? <Text style={styles.privateNotes} numberOfLines={1}>{item.privateNotes}</Text> : undefined}
+        onPress={() => onSelect(item)}
+      />
+    )
   }
 
   return (
@@ -35,5 +42,9 @@ const styles = StyleSheet.create({
   modalContent: {
     padding: 24,
     gap: 16,
+  },
+  privateNotes: {
+    fontSize: 12,
+    color: colors.on_surface_variant,
   },
 })

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -190,7 +190,7 @@ async function fetchUser(match: Record<string, unknown>): Promise<UserAuthRespon
         as: 'seasons',
       },
     },
-    { $project: { password: 0, userSeasonDocs: 0, seasonIds: 0, adminImageUrl: 0 } },
+    { $project: { password: 0, userSeasonDocs: 0, seasonIds: 0, adminImageUrl: 0, privateNotes: 0 } },
   ]).toArray()
 
   const [userAccount] = users

--- a/server/src/routes/seasons.ts
+++ b/server/src/routes/seasons.ts
@@ -70,6 +70,7 @@ seasons.get('/:id/users', authMiddleware, async (context) => {
           udiscId: '$user.udiscId',
           pdgaNumber: '$user.pdgaNumber',
           imageUrl: coalesceAdminImageUrl,
+          ...token.role === 'admin' ? { privateNotes: '$user.privateNotes' } : {},
           seasonId: { $toString: '$seasonId' },
           tagId: 1,
           entryPaid: 1,

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -114,7 +114,7 @@ users.get('/:id', authMiddleware, async (context) => {
   const users = await collection.aggregate([
     { $match: { _id: new ObjectId(id) } },
     ...coalesceAdminImageUrl,
-    { $unset: 'adminImageUrl' },
+    { $unset: token.role === 'admin' ? ['adminImageUrl'] : ['adminImageUrl', 'privateNotes'] },
   ]).toArray()
 
   return context.json(users.pop() ?? null)
@@ -139,6 +139,7 @@ users.post('/', authMiddleware, requireAdmin, async (context) => {
     udiscId: body.udiscId,
     pdgaNumber: body.pdgaNumber,
     adminImageUrl: body.imageUrl,
+    privateNotes: body.privateNotes,
   })
 
   if (body.seasonId) {
@@ -162,7 +163,7 @@ users.post('/', authMiddleware, requireAdmin, async (context) => {
 users.put('/:id', authMiddleware, async (context) => {
   const id = context.req.param('id')
   const body = await context.req.json()
-  const { seasonId, tagId, entryPaid, imageUrl, ...$set } = body
+  const { seasonId, tagId, entryPaid, imageUrl, privateNotes, ...$set } = body
   const token = getJwtPayload(context)
 
   if (token.role !== 'admin' && token._id.toString() !== id) {
@@ -182,6 +183,10 @@ users.put('/:id', authMiddleware, async (context) => {
     } else {
       $set.adminImageUrl = imageUrl
     }
+  }
+
+  if (privateNotes !== undefined && token.role === 'admin') {
+    $set.privateNotes = privateNotes
   }
 
   const update: Record<string, unknown> = { $set }

--- a/shared/models/api/userRequest.ts
+++ b/shared/models/api/userRequest.ts
@@ -3,6 +3,7 @@ export type UserRequest = {
   udiscId?: string,
   pdgaNumber?: string,
   imageUrl?: string,
+  privateNotes?: string,
   seasonId?: string,
   tagId?: number,
   entryPaid?: boolean,

--- a/shared/models/api/userResponse.ts
+++ b/shared/models/api/userResponse.ts
@@ -7,6 +7,7 @@ export type UserResponse = {
   udiscId?: string,
   pdgaNumber?: string,
   imageUrl?: string,
+  privateNotes?: string,
   role?: string,
   isReadonly?: boolean,
   deletedAt?: Date,

--- a/shared/models/user.ts
+++ b/shared/models/user.ts
@@ -9,6 +9,7 @@ export type User = {
   udiscId?: string,
   pdgaNumber?: string,
   imageUrl?: string,
+  privateNotes?: string,
   role: string,
   isAuthorized: boolean,
   isReadonly: boolean,

--- a/shared/schemas/userSchema.ts
+++ b/shared/schemas/userSchema.ts
@@ -6,6 +6,7 @@ export const userSchema = z.object({
   udiscId: z.string().optional(),
   pdgaNumber: z.string().optional(),
   imageUrl: z.string().optional(),
+  privateNotes: z.string().optional(),
 })
 
 export type UserSchemaInput = z.input<typeof userSchema>

--- a/shared/services/mappers.ts
+++ b/shared/services/mappers.ts
@@ -40,6 +40,7 @@ export function mapUser(source: UserJson): User {
     udiscId: source.udiscId,
     pdgaNumber: source.pdgaNumber,
     imageUrl: source.imageUrl,
+    privateNotes: source.privateNotes,
     role: '',
     isAuthorized: false,
     isReadonly: false,

--- a/shared/services/types.ts
+++ b/shared/services/types.ts
@@ -37,6 +37,7 @@ export type UserJson = {
   udiscId?: string,
   pdgaNumber?: string,
   imageUrl?: string,
+  privateNotes?: string,
 }
 
 export type UserSeasonJson = SeasonJson & UserJson & {

--- a/web/src/components/UserForm.vue
+++ b/web/src/components/UserForm.vue
@@ -23,6 +23,7 @@
   const tagId = ref(props.initialValues?.tagId)
   const entryPaid = ref(props.initialValues?.entryPaid ?? true)
   const imageUrl = ref(props.initialValues?.imageUrl)
+  const privateNotes = ref(props.initialValues?.privateNotes)
 
   const isRequired: ValidationRule<string | undefined> = (value) => value !== undefined && value.trim().length > 0
   const { error: nameErrorMessage, state: nameState } = useValidation(name, 'Name', [isRequired])
@@ -37,6 +38,7 @@
         tagId: tagId.value,
         entryPaid: entryPaid.value,
         imageUrl: imageUrl.value,
+        privateNotes: privateNotes.value,
       })
     }
   }
@@ -63,6 +65,14 @@
         <p-toggle :id="id" v-model="entryPaid" :disabled="auth.isReadonly" />
       </template>
     </p-label>
+
+    <template v-if="auth.role === 'admin'">
+      <p-label class="player-form__private-notes" label="Private Notes (admins only)">
+        <template #default="{ id }">
+          <p-textarea :id="id" v-model="privateNotes" :disabled="auth.isReadonly" />
+        </template>
+      </p-label>
+    </template>
 
     <template #footer>
       <p-button @click="emit('cancel')">

--- a/web/src/components/UsersList.vue
+++ b/web/src/components/UsersList.vue
@@ -23,6 +23,11 @@
         <p-list-item class="player-list__player-details" :value="player.id">
           <div class="player-list__player-details-name">
             {{ player.name }}
+            <template v-if="player.privateNotes">
+              <div class="player-list__player-details-notes">
+                {{ player.privateNotes }}
+              </div>
+            </template>
           </div>
           <UserImage :image-url="player.imageUrl" height="30" width="30" />
 
@@ -68,6 +73,11 @@
 
 .player-list__player-details-name {
   flex-grow: 1;
+}
+
+.player-list__player-details-notes {
+  font-size: .75rem;
+  color: var(--p-color-text-subdued);
 }
 
 .player-list__player-details-paid {


### PR DESCRIPTION
## What

Adds a `privateNotes` field to players that only admins can see or edit, modeled after the existing `adminImageUrl` pattern.

- **Server**: `privateNotes` is stored on the user document. It is stripped from `GET /users/:id` for non-admins, excluded from the non-admin `GET /users` projection, projected in `GET /seasons/:id/users` only for admins, and stripped from auth/JWT responses. `POST /users` (admin-only) saves it; `PUT /users/:id` destructures it out of the body spread and only applies it when the caller is an admin — without this, the existing `...$set` spread would let a player write their own notes via self-edit.
- **Shared**: `privateNotes?: string` added to `UserRequest`, `UserResponse`, `UserJson`, the `User` model, `mapUser`, and the zod `userSchema`.
- **Web**: `UserForm.vue` gains a "Private Notes (admins only)" textarea, rendered only for `auth.role === 'admin'`; `UsersList.vue` shows the note as a subdued line under the player name when present.
- **Mobile**: the players list passes the note through the `subTitle` prop of `PlayerListItem` (truncated to one line — added `flexShrink` so long notes ellipsize instead of overflowing); `PlayerForm` gains a multiline notes field covering both the edit and create screens.

## Why

Lets league admins keep private context on players (payment quirks, conduct notes, etc.) without exposing it to other players.

## Notes for reviewers

- Visibility is enforced entirely server-side, same as admin photos — non-admins never receive the field, so the frontends need no gating to be safe. The mobile app has no role gating anywhere, so the notes form field renders for everyone there, but non-admin reads come back empty and writes are ignored.
- MongoDB is schema-less, so no migration is needed.
- Pre-existing, untouched: web's `npm run typecheck` uses plain `tsc` and always fails on `.vue` imports (build's `vue-tsc` is the real check), and `vue-tsc` reports one unrelated error in `UDiscImportModal.vue` (`"secondary"` button variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)